### PR TITLE
fixes argparse format error

### DIFF
--- a/Cogent/reconstruct_contig.py
+++ b/Cogent/reconstruct_contig.py
@@ -276,7 +276,7 @@ if __name__ == "__main__":
     from argparse import ArgumentParser
     parser = ArgumentParser()
     parser.add_argument("dirname")
-    parser.add_argument("-e", "--expected_error_rate", type=int, default=1, help="Expected error rate (default: 1%)")
+    parser.add_argument("-e", "--expected_error_rate", type=int, default=1, help="Expected error rate (default: 1%%)")
     parser.add_argument("--nx_cycle_detection", default=False, action="store_true", help="Cycle detection using networkx (default: off), will increase run-time. Recommend for debugging failed cases only.")
     parser.add_argument("-k", "--kmer_size", type=int, default=30, help="kmer size (default: 30)")
     parser.add_argument("-p", "--output_prefix", help="Output path prefix (ex: sample1)")

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name='Cogent',
       author='Elizabeth Tseng',
       author_email='etseng@pacb.com',
       install_requires=[
+          'matplotlib >= 2.0.0, < 3.0.0',
           'numpy',
           'networkx==1.10',
           'scikit-image>=0.11.3',


### PR DESCRIPTION
format error otherwise occurs with argparse tries to format the help string with an unescaped '%' when 'reconstruct_contig.py -h' is executed