### PR TITLE
splice_align.py: make alignment work in the EXPECTED_ERR_RATE == 0 case.

### DIFF
--- a/Cogent/splice_align.py
+++ b/Cogent/splice_align.py
@@ -30,7 +30,7 @@ def node_is_similar(seq1, seq2):
     # and set min score to approx 90% accuracy
 
     if EXPECTED_ERR_RATE == 0:
-        res = os.align(seq2, min_score=l2*2*1.0, min_len=l2*1.0)
+        res = o1.align(seq2, min_score=l2*2*1.0, min_len=l2*1.0)
     elif EXPECTED_ERR_RATE < 2:
         res = o1.align(seq2, min_score=int(l1*2*.80), min_len=int(l2*.9))
     else:


### PR DESCRIPTION
Fixes a functional typo. Spotted during code reading, so I haven't actually tested this.